### PR TITLE
Drop --dangerous when installing from the store.

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -149,7 +149,6 @@ class PrometheusOvnExporterOperatorCharm(CharmBase):
                 [
                     "snap",
                     "install",
-                    "--dangerous",
                     f"--channel={self._stored.snap_channel}",
                     snap_file,
                 ]


### PR DESCRIPTION
The flag --dangerous is only valid when installing the snap from a file,
while when the installation is from the store passing the flag is
considered an error.